### PR TITLE
Remove "LICENSE.md" from "files" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "jstransformer"
   ],
   "files": [
-    "index.js",
-    "LICENSE.md"
+    "index.js"
   ],
   "devDependencies": {
     "istanbul": "^0.3.5",


### PR DESCRIPTION
It automatically includes all `*.md` files for us.