### PR TITLE
Add links in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ What you need to do:
 
 # jstransformer-foo
 
-Transformer that converts a string to foo.
+[Foo](http://example.com) support for [JSTransformers](http://github.com/jstransformers).
 
 [![Build Status](https://img.shields.io/travis/jstransformers/jstransformer-foo/master.svg)](https://travis-ci.org/jstransformers/jstransformer-foo)
 [![Coverage Status](https://img.shields.io/coveralls/jstransformers/jstransformer-foo/master.svg)](https://coveralls.io/r/jstransformers/jstransformer-foo?branch=master)


### PR DESCRIPTION
[Foo](http://example.com) support for [JSTransformers](http://github.com/jstransformers).