### PR TITLE
Fix tests to trim the output

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -16,27 +16,27 @@ var expected = fs.readFileSync(join(__dirname, 'expected.txt')).toString().trim(
 function assertEqual(output, expected) {
   console.log('   Output:\t'   + JSON.stringify(output));
   console.log('   Expected:\t' + JSON.stringify(expected));
-  assert.equal(output.trim(), expected);
+  assert.equal(output, expected);
 }
 
 if (transform.render) {
   test(transform.name + '.render()', function () {
     var output = transform.render(input, options, locals);
-    assertEqual(output, expected);
+    assertEqual(output.trim(), expected);
   });
 }
 
 if (transform.compile) {
   test(transform.name + '.compile()', function () {
     var output = transform.compile(input, options)(locals);
-    assertEqual(output, expected);
+    assertEqual(output.trim(), expected);
   });
 }
 
 if (transform.renderAsync) {
   test(transform.name + '.renderAsync()', function (done) {
     transform.renderAsync(input, options, locals).then(function (output) {
-      assertEqual(output, expected);
+      assertEqual(output.trim(), expected);
       done();
     }, function (err) {
       done(err);
@@ -47,7 +47,7 @@ if (transform.renderAsync) {
 if (transform.renderFileAsync) {
   test(transform.name + '.renderFileAsync()', function (done) {
     transform.renderFileAsync(inputFile, options, locals).then(function (output) {
-      assertEqual(output, expected);
+      assertEqual(output.trim(), expected);
       done();
     }, function (err) {
       done(err);


### PR DESCRIPTION
```
   Output:	"&lt;span class=&quot;foo&quot; id=&#39;bar&#39;&gt;hello world&lt;/span&gt;\n"
   Expected:	"&lt;span class=&quot;foo&quot; id=&#39;bar&#39;&gt;hello world&lt;/span&gt;"
 ✓ escape-html.render() (11ms)
```
While the tests pass, there's an extra \n at the end of output console log. Having the input to assertEqual() there will fix it.