### PR TITLE
Fix sort order of scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test-jstransformer": "^1.0.0"
   },
   "scripts": {
-    "test": "test-jstransformer",
-    "coverage": "test-jstransformer coverage"
+    "coverage": "test-jstransformer coverage",
+    "test": "test-jstransformer"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`npm` sometimes fixes the scripts to be alphabetized. This will avoid that change in the future.