### PR TITLE
Remove io.js from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "0.10"
   - "0.12"
   - "4"
-  - "iojs"
 
 after_success:
   - npm run coverage


### PR DESCRIPTION
Anyone using io.js should be on node 4.0.0 by now.