### PR TITLE
Add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,9 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
-# Dependency directory
-# Commenting this out is preferred by some people, see
-# https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
+# Dependency management
 node_modules
+package-lock.json
 
 # Users Environment Variables
 .lock-wscript


### PR DESCRIPTION
This ignores the lock file for Node.js 8. While you would want to commit this file to your applications folder, the JSTransformer packages will ignore them.