### PR TITLE
test: Removed Travis testing of Node.js 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "7"
   - "8"
   - "9"
+  - "10"
 
 after_success:
   - npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 sudo: false
 
 node_js:
-  - "4"
   - "6"
   - "7"
   - "8"


### PR DESCRIPTION
Node.js 4 End-of-life is 2018-04-30. We will be removing Travis testing for this release.

https://github.com/nodejs/Release